### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,6 +44,7 @@ jobs:
           mv "/tmp/kangal-${VERSION}"/* .
           make apply-crd
           sed -i "s/latest/local/" pkg/backends/jmeter/jmeter.go
+          sed -i "s/Always/IfNotPresent/" pkg/backends/jmeter/resources.go
           make build
 
       - name: Build Docker base image

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,26 +26,62 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Build Docker base image
-        uses: docker/build-push-action@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
         with:
-          tags: hellofreshtech/kangal-jmeter:latest
-          context: docker/jmeter-base
-          file: docker/jmeter-base/Dockerfile
+          go-version: '^1.15'
+
+      - name: Setup Kube in Docker
+        uses: engineerd/setup-kind@v0.4.0
+
+      - name: Setup latest Kangal release
+        run: |
+          mkdir kangal && cd kangal
+          VERSION=$(curl -fsSL "https://api.github.com/repos/hellofresh/kangal/releases" | jq --raw-output 'map(select(.tag_name|startswith("kangal")|not))[0] | .tag_name')
+          KANGAL_SOURCE_URL="https://github.com/hellofresh/kangal/archive/${VERSION}.tar.gz"
+          curl -X GET -H "Accept:application/octet-stream" -fsSL "$KANGAL_SOURCE_URL" > "/tmp/kangal-source.tar.gz"
+          tar -xzf "/tmp/kangal-source.tar.gz" -C /tmp
+          mv "/tmp/kangal-${VERSION}"/* .
+          make apply-crd
+          sed -i "s/latest/local/" pkg/backends/jmeter/jmeter.go
+          make build
+
+      - name: Build Docker base image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          repository: hellofreshtech/kangal-jmeter
+          tags: local
+          path: docker/jmeter-base
           push: false
 
       - name: Build Docker master image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1.1.0
         with:
-          tags: hellofreshtech/kangal-jmeter-master:latest
-          context: docker/jmeter-master
-          file: docker/jmeter-master/Dockerfile
+          repository: hellofreshtech/kangal-jmeter-master
+          tags: local
+          path: docker/jmeter-master
           push: false
+          build_args: VERSION=local
 
       - name: Build Docker worker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1.1.0
         with:
-          tags: hellofreshtech/kangal-jmeter-worker:latest
-          context: docker/jmeter-worker
-          file: docker/jmeter-worker/Dockerfile
+          repository: hellofreshtech/kangal-jmeter-worker
+          tags: local
+          path: docker/jmeter-worker
           push: false
+          build_args: VERSION=local
+
+      - name: Load docker images into kind cluster
+        run: |
+          docker images
+          kind load docker-image hellofreshtech/kangal-jmeter-master:local
+          kind load docker-image hellofreshtech/kangal-jmeter-worker:local
+
+      - name: Run Integration Test
+        env:
+          AWS_ENDPOINT_URL: "localhost:8081"
+          AWS_BUCKET_NAME: "kangal-test"
+        run: |
+          cd kangal
+          ./ci/integration-tests.sh


### PR DESCRIPTION
This PR adds integration test that tests changes on `kangal-jmeter` repository against latest `kangal` release.

#### Notes:
- `docker/build-push-action@v1.1.0` is used (instead of `@v2`) since v2 builds the image in a containerised docker; we need the behavior from version 1 so we can load the built docker image to `kind`.