### PR TITLE
Add support to persist reports using PreSigned URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Logging configuration in log4j2.xml is added to base image to support logging.
 ## Starting JMeter with launcher script
 Launcher.sh script runs in JMeter-master container, and it starts JMeter application in a container as soon as `test.jmx` file is added to the container.
 
-### Saving JMeter report to AWS S3 bucket
+### Saving JMeter report to storage
 JMeter automatically creates a test report after the successful test run.
-Launcher.sh uploads the report to S3 bucket. 
-JMeter-master docker image contains environment variables for connecting to AWS.
-- AWS_DEFAULT_REGION
-- ENV AWS_ENDPOINT_URL
-- ENV AWS_BUCKET_NAME
-Kangal initialises these variables when creating JMeter-master pods for every new test. 
+For every new test Kangal exports a environment variable called `REPORT_PRESIGNED_URL`, which allows uploading a single file to it by simple doing `PUT` request.
+JMeter-master docker image uses the script `launcher.sh` to upload the report by using this PreSigned URL.

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -9,13 +9,6 @@ ENV TESTS_DIR /tests
 ENV SLEEP 5
 ENV USE_WORKERS false
 
-ENV AWS_DEFAULT_REGION ""
-ENV AWS_ENDPOINT_URL ""
-ENV AWS_BUCKET_NAME ""
-
-RUN apt-get update && \
-    apt-get --quiet --yes install awscli
-
 COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-5.0/lib/
 COPY launcher.sh /
 

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -9,6 +9,9 @@ ENV TESTS_DIR /tests
 ENV SLEEP 5
 ENV USE_WORKERS false
 
+RUN apt-get update && \
+    apt-get --quiet --yes install awscli
+
 COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-5.0/lib/
 COPY launcher.sh /
 

--- a/docker/jmeter-master/launcher.sh
+++ b/docker/jmeter-master/launcher.sh
@@ -17,6 +17,11 @@ run_jmeter_test() {
         echo "=== Saving report to Object storage ==="
         tar -C /results -cf results.tar .
         curl -X PUT -H "Content-Type: application/x-tar" -T results.tar -L "${REPORT_PRESIGNED_URL}"
+      elif [[ -n "${AWS_BUCKET_NAME}" ]]; then
+        echo "WARNING: Using AWS credentials to upload reports is deprecated. Kangal upgrade is recommended."
+        echo "=== Trying to send report to ${AWS_BUCKET_NAME}/${LOADTEST_NAME} endpoint ${AWS_ENDPOINT_URL} ==="
+        cp /results/index.html /results/main.html
+        aws s3 cp --recursive /results s3://"${AWS_BUCKET_NAME}"/"${LOADTEST_NAME}"/ --endpoint-url https://"${AWS_ENDPOINT_URL}"
       fi
       exit 0
     fi

--- a/docker/jmeter-master/launcher.sh
+++ b/docker/jmeter-master/launcher.sh
@@ -15,7 +15,7 @@ run_jmeter_test() {
       echo "=== Jmeter is finished! ==="
       if [[ -n "${REPORT_PRESIGNED_URL}" ]]; then
         echo "=== Saving report to Object storage ==="
-        $(cd /results && tar -cf ${OLDPWD}/results.tar *)
+        tar -C /results -cf results.tar .
         curl -X PUT -H "Content-Type: application/x-tar" -T results.tar -L "${REPORT_PRESIGNED_URL}"
       fi
       exit 0

--- a/docker/jmeter-master/launcher.sh
+++ b/docker/jmeter-master/launcher.sh
@@ -13,13 +13,12 @@ run_jmeter_test() {
     cat output.log
     if grep "end of run" ./output.log; then
       echo "=== Jmeter is finished! ==="
-      echo "=== Trying to send report to ${AWS_BUCKET_NAME}/${LOADTEST_NAME} endpoint ${AWS_ENDPOINT_URL} ==="
-      if [[ -n "${AWS_BUCKET_NAME}" ]]; then
+      if [[ -n "${REPORT_PRESIGNED_URL}" ]]; then
         echo "=== Saving report to Object storage ==="
-        cp /results/index.html /results/main.html
-        aws s3 cp --recursive /results s3://"${AWS_BUCKET_NAME}"/"${LOADTEST_NAME}"/ --endpoint-url https://"${AWS_ENDPOINT_URL}"
+        $(cd /results && tar -cf ${OLDPWD}/results.tar *)
+        curl -X PUT -H "Content-Type: application/x-tar" -T results.tar -L "${REPORT_PRESIGNED_URL}"
       fi
-       exit 0
+      exit 0
     fi
     if JMETER_ERROR=$(grep "ERROR" ./output.log); then
       echo "=== We got an error while running JMeter, exiting 1 ==="


### PR DESCRIPTION
EES-3575

Master container cannot rely into AWS credentials anymore to persist reports.
Instead it can use the `REPORT_PRESIGNED_URL` environment variable to upload it.