### PR TITLE
Use hellofresh DockerHub org to push images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: hellofreshtech
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
       - name: Build and push Docker base image
         uses: docker/build-push-action@v2
         with:
-          tags: hellofreshtech/kangal-jmeter:latest
+          tags: hellofresh/kangal-jmeter:latest
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
           push: true
@@ -38,7 +38,7 @@ jobs:
       - name: Build and push Docker master image
         uses: docker/build-push-action@v2
         with:
-          tags: hellofreshtech/kangal-jmeter-master:latest
+          tags: hellofresh/kangal-jmeter-master:latest
           context: docker/jmeter-master
           file: docker/jmeter-master/Dockerfile
           push: true
@@ -46,7 +46,7 @@ jobs:
       - name: Build and push Docker worker image
         uses: docker/build-push-action@v2
         with:
-          tags: hellofreshtech/kangal-jmeter-worker:latest
+          tags: hellofresh/kangal-jmeter-worker:latest
           context: docker/jmeter-worker
           file: docker/jmeter-worker/Dockerfile
           push: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
           go-version: '^1.15'
 
       - name: Setup Kube in Docker
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
 
       - name: Setup latest Kangal release
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
           tar -xzf "/tmp/kangal-source.tar.gz" -C /tmp
           mv "/tmp/kangal-${VERSION}"/* .
           make apply-crd
-          sed -i "s/latest/local/" pkg/backends/jmeter/jmeter.go
+          sed -i "s/latest/local/" pkg/backends/jmeter/backend.go
           sed -i "s/Always/IfNotPresent/" pkg/backends/jmeter/resources.go
           make build
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build Docker base image
         uses: docker/build-push-action@v1.1.0
         with:
-          repository: hellofreshtech/kangal-jmeter
+          repository: hellofresh/kangal-jmeter
           tags: local
           path: docker/jmeter-base
           push: false
@@ -58,7 +58,7 @@ jobs:
       - name: Build Docker master image
         uses: docker/build-push-action@v1.1.0
         with:
-          repository: hellofreshtech/kangal-jmeter-master
+          repository: hellofresh/kangal-jmeter-master
           tags: local
           path: docker/jmeter-master
           push: false
@@ -67,7 +67,7 @@ jobs:
       - name: Build Docker worker image
         uses: docker/build-push-action@v1.1.0
         with:
-          repository: hellofreshtech/kangal-jmeter-worker
+          repository: hellofresh/kangal-jmeter-worker
           tags: local
           path: docker/jmeter-worker
           push: false
@@ -76,8 +76,8 @@ jobs:
       - name: Load docker images into kind cluster
         run: |
           docker images
-          kind load docker-image hellofreshtech/kangal-jmeter-master:local
-          kind load docker-image hellofreshtech/kangal-jmeter-worker:local
+          kind load docker-image hellofresh/kangal-jmeter-master:local
+          kind load docker-image hellofresh/kangal-jmeter-worker:local
 
       - name: Run Integration Test
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,6 @@ jobs:
           tar -xzf "/tmp/kangal-source.tar.gz" -C /tmp
           mv "/tmp/kangal-${VERSION}"/* .
           make apply-crd
-          sed -i "s/latest/local/" pkg/backends/jmeter/backend.go
           sed -i "s/Always/IfNotPresent/" pkg/backends/jmeter/resources.go
           make build
 
@@ -83,6 +82,10 @@ jobs:
         env:
           AWS_ENDPOINT_URL: "localhost:8081"
           AWS_BUCKET_NAME: "kangal-test"
+          JMETER_WORKER_IMAGE_NAME: "hellofresh/kangal-jmeter-worker"
+          JMETER_MASTER_IMAGE_NAME: "hellofresh/kangal-jmeter-master"
+          JMETER_WORKER_IMAGE_TAG: "local"
+          JMETER_MASTER_IMAGE_TAG: "local"
         run: |
           cd kangal
           ./ci/integration-tests.sh

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION="latest"
-FROM hellofreshtech/kangal-jmeter:$VERSION
+FROM hellofresh/kangal-jmeter:$VERSION
 
 ARG JMETER_VERSION=5.0
 

--- a/docker/jmeter-worker/Dockerfile
+++ b/docker/jmeter-worker/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION="latest"
-FROM hellofreshtech/kangal-jmeter:$VERSION
+FROM hellofresh/kangal-jmeter:$VERSION
 
 ARG JMETER_VERSION=5.0
 


### PR DESCRIPTION
This PR changes DockerHub account target to Hellofresh [official](https://hub.docker.com/u/hellofresh).