### PR TITLE
remove the depreceated zappr

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,6 +1,0 @@
-approvals:
-  groups:
-    pm:
-      minimum: 0
-    qa:
-      minimum: 0


### PR DESCRIPTION
Because zappr is depreceate, this PR removes the leftovers.