### PR TITLE
Upgrade to JMeter 5.4.1

### DIFF
--- a/docker/jmeter-base/Dockerfile
+++ b/docker/jmeter-base/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 LABEL maintainer="team-platform@hellofresh.com"
 
-ARG JMETER_VERSION=5.0
+ARG JMETER_VERSION=5.4.1
 
 ENV JMETER_HOME /opt/apache-jmeter-$JMETER_VERSION
 ENV PATH $JMETER_HOME/bin:$PATH

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION="latest"
 FROM hellofresh/kangal-jmeter:$VERSION
 
-ARG JMETER_VERSION=5.0
+ARG JMETER_VERSION=5.4.1
 
 ENV SSL_DISABLED false
 ENV WORKER_SVC_NAME jmeter-worker

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -12,7 +12,7 @@ ENV USE_WORKERS false
 RUN apt-get update && \
     apt-get --quiet --yes install awscli
 
-COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-5.0/lib/
+COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-$JMETER-VERSION/lib/
 COPY launcher.sh /
 
 ENTRYPOINT ["/launcher.sh"]

--- a/docker/jmeter-master/launcher.sh
+++ b/docker/jmeter-master/launcher.sh
@@ -5,7 +5,7 @@ run_jmeter_test() {
   [[ "$USE_WORKERS" == "true" ]] && WORKER_OPTS="-R $(getent ahostsv4 "$WORKER_SVC_NAME" | cut -d ' ' -f 1 | sort -u | paste --serial --delimiters ',')"
   echo "=== Running JMeter load generator ==="
 
-  /opt/apache-jmeter-5.0/bin/jmeter.sh -n -t "$FILE" -l results.csv -e -o /results/ -Jserver.rmi.ssl.disable="$SSL_DISABLED" "$WORKER_OPTS" >>output.log 2>&1 &
+  $JMETER_HOME/bin/jmeter.sh -n -t "$FILE" -l results.csv -e -o /results/ -Jserver.rmi.ssl.disable="$SSL_DISABLED" "$WORKER_OPTS" >>output.log 2>&1 &
 
   echo "Checking output.log"
   while true; do

--- a/docker/jmeter-master/launcher.sh
+++ b/docker/jmeter-master/launcher.sh
@@ -5,7 +5,7 @@ run_jmeter_test() {
   [[ "$USE_WORKERS" == "true" ]] && WORKER_OPTS="-R $(getent ahostsv4 "$WORKER_SVC_NAME" | cut -d ' ' -f 1 | sort -u | paste --serial --delimiters ',')"
   echo "=== Running JMeter load generator ==="
 
-  $JMETER_HOME/bin/jmeter.sh -n -t "$FILE" -l results.csv -e -o /results/ -Jserver.rmi.ssl.disable="$SSL_DISABLED" "$WORKER_OPTS" >>output.log 2>&1 &
+  "$JMETER_HOME"/bin/jmeter.sh -n -t "$FILE" -l results.csv -e -o /results/ -Jserver.rmi.ssl.disable="$SSL_DISABLED" "$WORKER_OPTS" >>output.log 2>&1 &
 
   echo "Checking output.log"
   while true; do

--- a/docker/jmeter-worker/Dockerfile
+++ b/docker/jmeter-worker/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION="latest"
 FROM hellofresh/kangal-jmeter:$VERSION
 
-ARG JMETER_VERSION=5.0
+ARG JMETER_VERSION=5.4.1
 
 ENV SSL_DISABLED false
 


### PR DESCRIPTION
This PR updates to latest available JMeter (5.4.1). It also upgrades the Java Runtime Environment (to 11).

I also took the liberty to change how the JMeter install location is referenced to make future upgrades easier.