### PR TITLE
Tag images with JMeter version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build docker image release
     runs-on: ubuntu-latest
     env:
-      JMETER_VERSION: 5.0
+      JMETER_VERSION: "5.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and push Docker base image
         uses: docker/build-push-action@v2
         with:
-          build-args: |
+          build_args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
           context: docker/jmeter-base
@@ -42,7 +42,7 @@ jobs:
       - name: Build and push Docker master image
         uses: docker/build-push-action@v2
         with:
-          build-args: |
+          build_args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
           context: docker/jmeter-master
@@ -52,7 +52,7 @@ jobs:
       - name: Build and push Docker worker image
         uses: docker/build-push-action@v2
         with:
-          build-args: |
+          build_args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
           context: docker/jmeter-worker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            JMETER_VERSION=${{env.JMETER_VERSION}}
+            VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            JMETER_VERSION=${{env.JMETER_VERSION}}
+            VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
           context: docker/jmeter-master
           file: docker/jmeter-master/Dockerfile
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            JMETER_VERSION=${{env.JMETER_VERSION}}
+            VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
           context: docker/jmeter-worker
           file: docker/jmeter-worker/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           build-args: |
             VERSION=${{env.JMETER_VERSION}}
-          tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
+          tags: |
+            hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
+            hellofresh/kangal-jmeter:latest
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
           push: true
@@ -44,7 +46,9 @@ jobs:
         with:
           build-args: |
             VERSION=${{env.JMETER_VERSION}}
-          tags: hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
+          tags: |
+            hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
+            hellofresh/kangal-jmeter-master:latest
           context: docker/jmeter-master
           file: docker/jmeter-master/Dockerfile
           push: true
@@ -54,7 +58,9 @@ jobs:
         with:
           build-args: |
             VERSION=${{env.JMETER_VERSION}}
-          tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
+          tags: |
+            hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
+            hellofresh/kangal-jmeter-worker:latest
           context: docker/jmeter-worker
           file: docker/jmeter-worker/Dockerfile
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and push Docker base image
         uses: docker/build-push-action@v2
         with:
-          build_args: |
+          build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
           context: docker/jmeter-base
@@ -42,7 +42,7 @@ jobs:
       - name: Build and push Docker master image
         uses: docker/build-push-action@v2
         with:
-          build_args: |
+          build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
           context: docker/jmeter-master
@@ -52,7 +52,7 @@ jobs:
       - name: Build and push Docker worker image
         uses: docker/build-push-action@v2
         with:
-          build_args: |
+          build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
           context: docker/jmeter-worker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build_docker:
     name: Build docker image release
     runs-on: ubuntu-latest
+    env:
+      JMETER_VERSION: 5.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -30,7 +32,9 @@ jobs:
       - name: Build and push Docker base image
         uses: docker/build-push-action@v2
         with:
-          tags: hellofresh/kangal-jmeter:latest
+          build-args: |
+            JMETER_VERSION=${{env.JMETER_VERSION}}
+          tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
           push: true
@@ -38,7 +42,9 @@ jobs:
       - name: Build and push Docker master image
         uses: docker/build-push-action@v2
         with:
-          tags: hellofresh/kangal-jmeter-master:latest
+          build-args: |
+            JMETER_VERSION=${{env.JMETER_VERSION}}
+          tags: hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
           context: docker/jmeter-master
           file: docker/jmeter-master/Dockerfile
           push: true
@@ -46,7 +52,9 @@ jobs:
       - name: Build and push Docker worker image
         uses: docker/build-push-action@v2
         with:
-          tags: hellofresh/kangal-jmeter-worker:latest
+          build-args: |
+            JMETER_VERSION=${{env.JMETER_VERSION}}
+          tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
           context: docker/jmeter-worker
           file: docker/jmeter-worker/Dockerfile
           push: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      JMETER_VERSION: 5.0
+      JMETER_VERSION: "5.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
           build_args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           repository: hellofresh/kangal-jmeter
-          tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
+          tags: ${{env.JMETER_VERSION}}
           path: docker/jmeter-base
           push: false
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,33 +49,33 @@ jobs:
           make build
 
       - name: Build Docker base image
-        uses: docker/build-push-action@v1.1.0
+        uses: docker/build-push-action@v2
         with:
-          build_args: |
+          build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
-          repository: hellofresh/kangal-jmeter
-          tags: ${{env.JMETER_VERSION}}
-          path: docker/jmeter-base
+          tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
+          context: docker/jmeter-base
+          file: docker/jmeter-base/Dockerfile
           push: false
 
       - name: Build Docker master image
-        uses: docker/build-push-action@v1.1.0
+        uses: docker/build-push-action@v2
         with:
-          repository: hellofresh/kangal-jmeter-master
-          tags: local
-          path: docker/jmeter-master
+          tags: hellofresh/kangal-jmeter-master:local
+          context: docker/jmeter-master
+          file: docker/jmeter-master/Dockerfile
           push: false
-          build_args: |
+          build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Build Docker worker image
-        uses: docker/build-push-action@v1.1.0
+        uses: docker/build-push-action@v2
         with:
-          repository: hellofresh/kangal-jmeter-worker
-          tags: local
-          path: docker/jmeter-worker
+          tags: hellofresh/kangal-jmeter-worker:local
+          context: docker/jmeter-worker
+          file: docker/jmeter-worker/Dockerfile
           push: false
-          build_args: |
+          build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Load docker images into kind cluster

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            JMETER_VERSION=${{env.JMETER_VERSION}}
+            VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
@@ -66,7 +66,7 @@ jobs:
           file: docker/jmeter-master/Dockerfile
           push: false
           build-args: |
-            JMETER_VERSION=${{env.JMETER_VERSION}}
+            VERSION=${{env.JMETER_VERSION}}
 
       - name: Build Docker worker image
         uses: docker/build-push-action@v2
@@ -76,7 +76,7 @@ jobs:
           file: docker/jmeter-worker/Dockerfile
           push: false
           build-args: |
-            JMETER_VERSION=${{env.JMETER_VERSION}}
+            VERSION=${{env.JMETER_VERSION}}
 
       - name: Load docker images into kind cluster
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      JMETER_VERSION: 5.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -49,8 +51,10 @@ jobs:
       - name: Build Docker base image
         uses: docker/build-push-action@v1.1.0
         with:
+          build_args: |
+            JMETER_VERSION=${{env.JMETER_VERSION}}
           repository: hellofresh/kangal-jmeter
-          tags: local
+          tags: hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
           path: docker/jmeter-base
           push: false
 
@@ -61,7 +65,8 @@ jobs:
           tags: local
           path: docker/jmeter-master
           push: false
-          build_args: VERSION=local
+          build_args: |
+            JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Build Docker worker image
         uses: docker/build-push-action@v1.1.0
@@ -70,7 +75,8 @@ jobs:
           tags: local
           path: docker/jmeter-worker
           push: false
-          build_args: VERSION=local
+          build_args: |
+            JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Load docker images into kind cluster
         run: |


### PR DESCRIPTION
In order to enable JMeter version upgrade we need to change the current build process for Docker images.

First, we need to change the tag for existing images with JMeter 5.0.
`hellofresh/kangal-jmeter-master:latest`  ->  `hellofresh/kangal-jmeter-master:5.0`

This PR adds env JMETER_VERSION to the build workflow and makes use of it in every image build. Also, every image is now tagged with JMeter version.