### PR TITLE
Put jmeter.properties version

### DIFF
--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
     apt-get --quiet --yes install awscli
 
 COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-5.0/lib/
+COPY jmeter.properties /opt/apache-jmeter-$JMETER_VERSION/bin/
 COPY launcher.sh /
 
 ENTRYPOINT ["/launcher.sh"]

--- a/docker/jmeter-master/jmeter.properties
+++ b/docker/jmeter-master/jmeter.properties
@@ -1,0 +1,22 @@
+num_sample_threshold=5
+time_threshold=1000
+#---------------------------------------------------------------------------
+# Results file configuration
+#---------------------------------------------------------------------------
+jmeter.save.saveservice.output_format=csv
+jmeter.save.saveservice.response_data=true
+jmeter.save.saveservice.response_data.on_error=true
+jmeter.save.saveservice.response_message=true
+#---------------------------------------------------------------------------
+# Additional property files to load
+#---------------------------------------------------------------------------
+user.properties=user.properties
+system.properties=system.properties
+#---------------------------------------------------------------------------
+# Reporting configuration
+#---------------------------------------------------------------------------
+jmeter.reportgenerator.apdex_satisfied_threshold=200
+jmeter.reportgenerator.apdex_tolerated_threshold=500
+jmeter.reportgenerator.report_title=Kangal JMeter Dashboard
+jmeter.reportgenerator.overall_granularity=10000
+jmeter.save.saveservice.timestamp_format = yyyy/MM/dd HH:mm:ss zzz


### PR DESCRIPTION
Currently we are creating `jmeter.properties` file via [Kangal controller](https://github.com/hellofresh/kangal/blob/master/pkg/backends/jmeter/resources.go) for no good reason.

This PR simply puts this file in `kangal-jmeter-master` image. We will remove the same thing from Kangal controller in future changes.