### PR TITLE
Prepare JMeter 5.4.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build docker image release
     runs-on: ubuntu-latest
     env:
-      JMETER_VERSION: "5.0"
+      JMETER_VERSION: "5.4.1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            VERSION=${{env.JMETER_VERSION}}
+            JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: |
             hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
             hellofresh/kangal-jmeter:latest
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            VERSION=${{env.JMETER_VERSION}}
+            JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: |
             hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
             hellofresh/kangal-jmeter-master:latest
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            VERSION=${{env.JMETER_VERSION}}
+            JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: |
             hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
             hellofresh/kangal-jmeter-worker:latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      JMETER_VERSION: "5.0"
+      JMETER_VERSION: "5.4.1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            VERSION=${{env.JMETER_VERSION}}
+            JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
@@ -66,7 +66,7 @@ jobs:
           file: docker/jmeter-master/Dockerfile
           push: false
           build-args: |
-            VERSION=${{env.JMETER_VERSION}}
+            JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Build Docker worker image
         uses: docker/build-push-action@v2
@@ -76,7 +76,7 @@ jobs:
           file: docker/jmeter-worker/Dockerfile
           push: false
           build-args: |
-            VERSION=${{env.JMETER_VERSION}}
+            JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Load docker images into kind cluster
         run: |

--- a/docker/jmeter-base/Dockerfile
+++ b/docker/jmeter-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 LABEL maintainer="team-platform@hellofresh.com"
 
-ARG JMETER_VERSION=5.4.1
+ARG JMETER_VERSION
 
 ENV JMETER_HOME /opt/apache-jmeter-$JMETER_VERSION
 ENV PATH $JMETER_HOME/bin:$PATH

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -1,7 +1,5 @@
-ARG VERSION="latest"
-FROM hellofresh/kangal-jmeter:$VERSION
-
-ARG JMETER_VERSION=5.4.1
+ARG JMETER_VERSION
+FROM hellofresh/kangal-jmeter:$JMETER_VERSION
 
 ENV SSL_DISABLED false
 ENV WORKER_SVC_NAME jmeter-worker

--- a/docker/jmeter-worker/Dockerfile
+++ b/docker/jmeter-worker/Dockerfile
@@ -1,7 +1,5 @@
-ARG VERSION="latest"
-FROM hellofresh/kangal-jmeter:$VERSION
-
-ARG JMETER_VERSION=5.4.1
+ARG JMETER_VERSION
+FROM hellofresh/kangal-jmeter:$JMETER_VERSION
 
 ENV SSL_DISABLED false
 


### PR DESCRIPTION
This PR:
- Defines JMeter version in workflow file instead of dockerfile for both build and release process
- Bumps JMeter version from `5.0` to `5.4.1`

Co-authored by: @s-radyuk, @diegomarangoni 