### PR TITLE
restore AGR JMETER_VERSION in jmeter-master Dockerfile

### DIFF
--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -1,6 +1,8 @@
 ARG JMETER_VERSION
 FROM hellofresh/kangal-jmeter:$JMETER_VERSION
 
+ARG JMETER_VERSION
+
 ENV SSL_DISABLED false
 ENV WORKER_SVC_NAME jmeter-worker
 ENV TESTS_DIR /tests

--- a/docker/jmeter-master/Dockerfile
+++ b/docker/jmeter-master/Dockerfile
@@ -12,7 +12,7 @@ ENV USE_WORKERS false
 RUN apt-get update && \
     apt-get --quiet --yes install awscli
 
-COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-$JMETER-VERSION/lib/
+COPY mysql-connector-java-5.1.47-bin.jar /opt/apache-jmeter-$JMETER_VERSION/lib/
 COPY jmeter.properties /opt/apache-jmeter-$JMETER_VERSION/bin/
 COPY launcher.sh /
 


### PR DESCRIPTION
We need to restore `ARG JMETER_VERSION` after `FROM` stet to make it visible and use it for correct path creation. Without it, we have a broken path for jmeter.properties file.
<img width="600" alt="Screenshot 2021-05-27 at 17 45 24" src="https://user-images.githubusercontent.com/21171767/119857221-acd73180-bf13-11eb-86bf-2f6c15752a57.png">
