### PR TITLE
Remove usage of the deprecated GitHub Actions commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get the version from ref
         if: success()
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Docker base image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
@@ -44,7 +44,7 @@ jobs:
           push: true
 
       - name: Build and push Docker master image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
@@ -56,7 +56,7 @@ jobs:
           push: true
 
       - name: Build and push Docker worker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,7 +77,7 @@ jobs:
           make build
 
       - name: Build Docker base image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
@@ -87,7 +87,7 @@ jobs:
           push: false
 
       - name: Build Docker master image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           tags: hellofresh/kangal-jmeter-master:local
           context: docker/jmeter-master
@@ -97,7 +97,7 @@ jobs:
             JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Build Docker worker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           tags: hellofresh/kangal-jmeter-worker:local
           context: docker/jmeter-worker


### PR DESCRIPTION
## What does this PR do?

1. Removes usage of the deprecated set-output GitHub Actions command in GitHub Workflows and writes to the `GITHUB_OUTPUT` environment file instead.
2. Bumps the version of `docker/build-push-action` from v2 to v3 to fix the warning: _The `save-state` command is deprecated and will be disabled soon_.

ℹ️ To be merged after https://github.com/hellofresh/kangal-jmeter/pull/25