### PR TITLE
Update version of cmdrunner from 2.2 to 2.3

### DIFF
--- a/docker/jmeter-base/Dockerfile
+++ b/docker/jmeter-base/Dockerfile
@@ -24,8 +24,8 @@ RUN curl -o /opt/apache-jmeter-$JMETER_VERSION.tgz \
  && rm /opt/apache-jmeter-$JMETER_VERSION.tgz \
  && curl -o /opt/apache-jmeter-$JMETER_VERSION/lib/ext/plugins-manager.jar -L \
     https://jmeter-plugins.org/get/ \
- && curl -o /opt/apache-jmeter-$JMETER_VERSION/lib/cmdrunner-2.2.jar -L \
-    http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar \
+ && curl -o /opt/apache-jmeter-$JMETER_VERSION/lib/cmdrunner-2.3.jar -L \
+    https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.3/cmdrunner-2.3.jar \
  && curl -o /opt/apache-jmeter-$JMETER_VERSION/lib/postgresql-42.2.5.jar -L \
     https://jdbc.postgresql.org/download/postgresql-42.2.5.jar \
  && java -cp /opt/apache-jmeter-$JMETER_VERSION/lib/ext/plugins-manager.jar \


### PR DESCRIPTION
To fix the following error when building the Docker image:
```
Error: Unable to access jarfile /opt/apache-jmeter-5.4.1/bin/../lib/cmdrunner-2.3.jar
```

This will fix the [testing workflow](https://github.com/hellofresh/kangal-jmeter/blob/master/.github/workflows/testing.yml), see the current error [here](https://github.com/hellofresh/kangal-jmeter/actions/runs/3481455286/jobs/5822566852#step:7:397).

ℹ️ This was originally part of https://github.com/hellofresh/kangal-jmeter/pull/24, but decided to move it to its own PR ✨ to make it easier to review and merge, separately, and make the git history more clear.