### PR TITLE
Bump the version of JMeter from 5.4.1 to 5.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build docker image release
     runs-on: ubuntu-latest
     env:
-      JMETER_VERSION: "5.4.1"
+      JMETER_VERSION: "5.5"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      JMETER_VERSION: "5.4.1"
+      JMETER_VERSION: "5.5"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/docker/jmeter-base/Dockerfile
+++ b/docker/jmeter-base/Dockerfile
@@ -2,12 +2,6 @@ FROM openjdk:11-jre-slim
 LABEL maintainer="team-platform@hellofresh.com"
 
 ARG JMETER_VERSION
-
-# precaution against CVE-2021-44228 and CVE-2021-45046
-# https://www.ubik-ingenierie.com/blog/jmeter-log4j-vulnerability/
-# TODO remove once we upgraded to jmeter 5.5 or 6.0
-ENV _JAVA_OPTIONS='-Dlog4j2.formatMsgNoLookups=true' JAVA_TOOLS_OPTIONS='-Dlog4j2.formatMsgNoLookups=true'
-
 ENV JMETER_HOME /opt/apache-jmeter-$JMETER_VERSION
 ENV PATH $JMETER_HOME/bin:$PATH
 ENV HEAP -Xms2g -Xmx2g -XX:MaxMetaspaceSize=256m


### PR DESCRIPTION
And remove the patch against CVE-2021-44228 and CVE-2021-45046 since JMeter 5.5 ships with log4j2 2.17.2 (that includes the patches against the mentioned CVEs).