### PR TITLE
RES-1 Change to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,13 @@ name: Building Release Docker images
 
 concurrency: release
 
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
 on:
   release:
     types:
@@ -15,7 +22,7 @@ jobs:
       JMETER_VERSION: "5.5"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Get the version from ref
         if: success()
@@ -23,46 +30,47 @@ jobs:
         run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
-          username: hellofreshtech
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker base image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: |
-            hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
-            hellofresh/kangal-jmeter:latest
+            ${{env.REGISTRY}}/hellofresh/kangal-jmeter:${{env.JMETER_VERSION}}
+            ${{env.REGISTRY}}/hellofresh/kangal-jmeter:latest
           context: docker/jmeter-base
           file: docker/jmeter-base/Dockerfile
           push: true
 
       - name: Build and push Docker master image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: |
-            hellofresh/kangal-jmeter-master:${{env.JMETER_VERSION}}
-            hellofresh/kangal-jmeter-master:latest
+            ${{env.REGISTRY}}/hellofresh/kangal-jmeter/master:${{env.JMETER_VERSION}}
+            ${{env.REGISTRY}}/hellofresh/kangal-jmeter/master:latest
           context: docker/jmeter-master
           file: docker/jmeter-master/Dockerfile
           push: true
 
       - name: Build and push Docker worker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
           tags: |
-            hellofresh/kangal-jmeter-worker:${{env.JMETER_VERSION}}
-            hellofresh/kangal-jmeter-worker:latest
+            ${{env.REGISTRY}}/hellofresh/kangal-jmeter/worker:${{env.JMETER_VERSION}}
+            ${{env.REGISTRY}}/hellofresh/kangal-jmeter/worker:latest
           context: docker/jmeter-worker
           file: docker/jmeter-worker/Dockerfile
           push: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -89,7 +89,7 @@ jobs:
           push: false
 
       - name: Build Docker master image
-        uses: docker/build-push-action@v3=6
+        uses: docker/build-push-action@v6
         with:
           tags: hellofresh/kangal-jmeter-master:local
           context: docker/jmeter-master

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Run General Linting
-        uses: docker://ghcr.io/github/super-linter:slim-v4
+        uses: docker://ghcr.io/github/super-linter:slim-v5
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GO: false
@@ -38,15 +40,15 @@ jobs:
       JMETER_VERSION: "5.5"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.15'
 
       - name: Setup Kube in Docker
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@v0.6.2
         with:
           version: "v0.11.1"
 
@@ -64,7 +66,7 @@ jobs:
       #          make build
 
       - name: Checkout Kangal code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: hellofresh/kangal
           path: kangal
@@ -77,7 +79,7 @@ jobs:
           make build
 
       - name: Build Docker base image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             JMETER_VERSION=${{env.JMETER_VERSION}}
@@ -87,7 +89,7 @@ jobs:
           push: false
 
       - name: Build Docker master image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3=6
         with:
           tags: hellofresh/kangal-jmeter-master:local
           context: docker/jmeter-master
@@ -97,7 +99,7 @@ jobs:
             JMETER_VERSION=${{env.JMETER_VERSION}}
 
       - name: Build Docker worker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           tags: hellofresh/kangal-jmeter-worker:local
           context: docker/jmeter-worker

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Based on these images Kangal creates JMeter-worker and JMeter-master pods automa
 
 > [!WARNING]
 > Kangal's upload to DockerHub has been removed
-> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal-jmeter/*` from January 31st onwards.
+> We apologize for the disruption, but you can get the image from
+> `ghcr.io/hellofresh/kangal-jmeter`, `ghcr.io/hellofresh/kangal-jmeter/master`, and `ghcr.io/hellofresh/kangal-jmeter/worker` from January 31st 2026 onwards.
 >
-> The registry in DockerHub will not be available from February-onwards
+> The registry in DockerHub will not be available from February 2026 onwards
 
 ## Kangal-JMeter specific features
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Kangal-JMeter
-<p align="center">  
+<p align="center">
 <img src="./kangal_logo.svg" height="100">
 <img src="./hellofresh.svg" height="100">
 </p>
@@ -7,6 +7,12 @@
 Kangal-JMeter is a set of docker images specifically configured for [Kangal](https://github.com/hellofresh/kangal)
 
 Based on these images Kangal creates JMeter-worker and JMeter-master pods automatically for every new load-test.
+
+> [!WARNING]
+> Kangal's upload to DockerHub has been removed
+> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal-jmeter/*` from January 31st onwards.
+>
+> The registry in DockerHub will not be available from February-onwards
 
 ## Kangal-JMeter specific features
 

--- a/docker/jmeter-base/Dockerfile
+++ b/docker/jmeter-base/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:11.0.11-jre-slim
+# TODO: openjdk images are deprecated, find a suitable replacement.
 LABEL maintainer="team-platform@hellofresh.com"
 
 ARG JMETER_VERSION


### PR DESCRIPTION
We must change to ghcr, since DockerHub won't be an available target in the future